### PR TITLE
Recursive Descent PML parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+out/
+*.class

--- a/src/org/usfirst/frc/team5002/io/config/parse/ParameterizedIdentifier.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/ParameterizedIdentifier.java
@@ -1,0 +1,14 @@
+package org.usfirst.frc.team5002.io.config.parse;
+
+public class ParameterizedIdentifier {
+    private String ident;
+    private ArrayList<String> params;
+
+    public constructor(String identifier, ArrayList<String> parameters) {
+        this.identifier = identifier;
+        this.parameters = parameters;
+    }
+
+    public String identifier() { return ident; }
+    public ArrayList<String> parameters() { return params; }
+}

--- a/src/org/usfirst/frc/team5002/io/config/parse/ParameterizedIdentifier.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/ParameterizedIdentifier.java
@@ -1,14 +1,31 @@
 package org.usfirst.frc.team5002.io.config.parse;
 
+import java.util.ArrayList;
+
 public class ParameterizedIdentifier {
     private String ident;
     private ArrayList<String> params;
 
-    public constructor(String identifier, ArrayList<String> parameters) {
-        this.identifier = identifier;
-        this.parameters = parameters;
+    public ParameterizedIdentifier(
+        String identifier, ArrayList<String> parameters
+    ) {
+        this.ident = identifier;
+        this.params = parameters;
     }
 
     public String identifier() { return ident; }
     public ArrayList<String> parameters() { return params; }
+
+    public String toString() {
+        StringBuilder b = new StringBuilder();
+
+        b.append(ident+'(');
+        for(int i=0;i<params.size(); i++) {
+            b.append(params.get(i));
+            if(i != params.size()-1) b.append(',');
+        }
+        b.append(')');
+
+        return b.toString();
+    }
 }

--- a/src/org/usfirst/frc/team5002/io/config/parse/PipelineSpecification.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/PipelineSpecification.java
@@ -1,0 +1,35 @@
+package org.usfirst.frc.team5002.io.config.parse;
+
+public class PipelineSpecification {
+    private String device;
+    private String input;
+    private ParameterizedIdentifier filter;
+    private String callback;
+    private ArrayList<ParameterizedIdentifier> stages;
+
+    public constructor(
+        String device, String input, ParameterizedIdentifier filter)
+    {
+        this.device = device;
+        this.input = input;
+        this.filter = filter;
+    }
+
+    public void setDevice(String device) { this.device = device; }
+    public void setInput(String input) { this.input = input; }
+
+    public void setFilter(ParameterizedIdentifier filter) {
+        this.filter = filter;
+    }
+
+    public void setCallback(String callback) { this.callback = callback; }
+    public void setStages(ArrayList<ParameterizedIdentifier> stages) {
+        this.stages = stages;
+    }
+
+    public String device() { return this.device; }
+    public String input() { return this.input; }
+    public ParameterizedIdentifier filter() { return this.filter; }
+    public String callback() { return this.callback; }
+    public ArrayList<ParameterizedIdentifier> stages() { return this.stages; }
+}

--- a/src/org/usfirst/frc/team5002/io/config/parse/PipelineSpecification.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/PipelineSpecification.java
@@ -1,5 +1,7 @@
 package org.usfirst.frc.team5002.io.config.parse;
 
+import java.util.ArrayList;
+
 public class PipelineSpecification {
     private String device;
     private String input;
@@ -7,7 +9,7 @@ public class PipelineSpecification {
     private String callback;
     private ArrayList<ParameterizedIdentifier> stages;
 
-    public constructor(
+    public PipelineSpecification(
         String device, String input, ParameterizedIdentifier filter)
     {
         this.device = device;

--- a/src/org/usfirst/frc/team5002/io/config/parse/RDParserTest.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/RDParserTest.java
@@ -1,0 +1,86 @@
+/**
+ * @file RDParserTest.java
+ * Implements (non-automated) testing for the recursive descent PML parser.
+ *
+ * @author Sebastian Mobo
+ * @version 0.1.0
+ * @date 04-Nov-2017
+ */
+
+package org.usfirst.frc.team5002.io.config.parse;
+
+import java.util.regex.Pattern;
+import org.usfirst.frc.team5002.io.config.parse.RecursiveDescentParser;
+import org.usfirst.frc.team5002.io.config.exception.ConfigParseException;
+
+/**
+ * Simple class for testing the recursive descent parser.
+ * @see RecursiveDescentParser.java
+ * @author Sebastian Mobo
+ * @version 0.1.0
+ * @date 04-Nov-2017
+ */
+class RDParserTest {
+    private static void testOutput(String input, boolean status, boolean exp) {
+        System.out.println(
+            input
+            + "\n    parse status: " + String.valueOf(status)
+            + " (should be "+String.valueOf(exp)+")"
+        );
+    }
+
+    private static void testOutput(
+        String input, ConfigParseException e, boolean exp)
+    {
+        System.out.println(
+            input
+            + "\n    parse status: syntax error - "
+            + e.getMessage()
+            + " (should be "+String.valueOf(exp)+")"
+        );
+    }
+
+    private static void syntaxErrOutput(String input, boolean status) {
+        System.out.println(
+            input
+            + "\n    parse status: " + String.valueOf(status)
+            + " (should be a syntax error)"
+        );
+    }
+
+    private static void syntaxErrOutput(String input, ConfigParseException e) {
+        System.out.println(
+            input
+            + "\n    parse status: syntax error - "
+            + e.getMessage()
+            + " (should be a syntax error)"
+        );
+    }
+
+    public static void main(String[] args) {
+        String parserTest1 = "gamepad1.left_joystick_y :: always  |-> foc ->| forward;";
+        String parserTest2 = "10";
+        String parserTest3 = "this.causes :: an |-> error";
+
+        try {
+            boolean test1 = RecursiveDescentParser.parse(parserTest1);
+            testOutput(parserTest1, test1, true);
+        } catch(ConfigParseException e) {
+            testOutput(parserTest1, e, true);
+        }
+
+        try {
+            boolean test2 = RecursiveDescentParser.parse(parserTest2);
+            testOutput(parserTest2, test2, false);
+        } catch(ConfigParseException e) {
+            testOutput(parserTest2, e, false);
+        }
+
+        try {
+            boolean test3 = RecursiveDescentParser.parse(parserTest3);
+            syntaxErrOutput(parserTest3, test3);
+        } catch(ConfigParseException e) {
+            syntaxErrOutput(parserTest3, e);
+        }
+    }
+}

--- a/src/org/usfirst/frc/team5002/io/config/parse/RDParserTest.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/RDParserTest.java
@@ -63,20 +63,17 @@ class RDParserTest {
     }
 
     public static void main(String[] args) {
-        String parserTest1 = "gamepad1.left_joystick_y :: always  |-> foc ->| forward;";
-        String parserTest2 = "10";
-        String parserTest3 = "this.causes :: an |-> error";
         String parserTest4 =
             "gamepad1.right_joystick_x\n"+
             "   :: always |->| logging, # note the comma at the end of this line.\n"+
             "   # and the semicolon terminating the whole statement.\n"+
             "   :: changed |-> deadband(0.01) |-> FOC ->| twist;\n";
-        String parserTest5 = "gamepad1.right_joystick_x :: |->| logging";
 
-        parsingTest(parserTest1);
-        parsingTest(parserTest2);
-        parsingTest(parserTest3);
+        parsingTest("gamepad1.left_joystick_y :: always  |-> foc ->| forward;");
+        parsingTest("10");
+        parsingTest("this.causes :: an |-> error");
+        parsingTest("this.however :: is -> not -> an ->| error");
         parsingTest(parserTest4);
-        parsingTest(parserTest5);
+        parsingTest("gamepad1.right_joystick_x :: |->| logging");
     }
 }

--- a/src/org/usfirst/frc/team5002/io/config/parse/RDParserTest.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/RDParserTest.java
@@ -9,6 +9,7 @@
 
 package org.usfirst.frc.team5002.io.config.parse;
 
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 import org.usfirst.frc.team5002.io.config.parse.RecursiveDescentParser;
 import org.usfirst.frc.team5002.io.config.exception.ConfigParseException;
@@ -21,66 +22,61 @@ import org.usfirst.frc.team5002.io.config.exception.ConfigParseException;
  * @date 04-Nov-2017
  */
 class RDParserTest {
-    private static void testOutput(String input, boolean status, boolean exp) {
-        System.out.println(
-            input
-            + "\n    parse status: " + String.valueOf(status)
-            + " (should be "+String.valueOf(exp)+")"
-        );
-    }
-
-    private static void testOutput(
-        String input, ConfigParseException e, boolean exp)
-    {
-        System.out.println(
-            input
-            + "\n    parse status: syntax error - "
-            + e.getMessage()
-            + " (should be "+String.valueOf(exp)+")"
-        );
-    }
-
-    private static void syntaxErrOutput(String input, boolean status) {
-        System.out.println(
-            input
-            + "\n    parse status: " + String.valueOf(status)
-            + " (should be a syntax error)"
-        );
-    }
-
     private static void syntaxErrOutput(String input, ConfigParseException e) {
         System.out.println(
             input
-            + "\n    parse status: syntax error - "
+            + "\n    parse status: syntax error: \n"
             + e.getMessage()
-            + " (should be a syntax error)"
         );
+    }
+
+    private static void displayPipelineSpec(PipelineSpecification spec) {
+        System.out.println("Device: " + spec.device());
+        System.out.println("Input: " + spec.input());
+        System.out.println("Filter: " + spec.filter());
+        System.out.println("Stages:");
+        for(ParameterizedIdentifier stage : spec.stages()) {
+            System.out.println("    " + stage.toString());
+        }
+        System.out.println("Callback: " + spec.callback());
+    }
+
+    private static void parsingTest(String input) {
+        try {
+            ArrayList<PipelineSpecification> test
+                = RecursiveDescentParser.parse(input);
+
+            System.out.println("Parse of: ");
+            System.out.println(input);
+            System.out.println("--------------");
+            int i=0;
+            for (PipelineSpecification spec : test) {
+                i++;
+                System.out.println("Specification "+String.valueOf(i)+':');
+                displayPipelineSpec(spec);
+                System.out.println("--------------");
+            }
+        } catch(ConfigParseException e) {
+            syntaxErrOutput(input, e);
+            System.out.println("--------------");
+        }
     }
 
     public static void main(String[] args) {
         String parserTest1 = "gamepad1.left_joystick_y :: always  |-> foc ->| forward;";
         String parserTest2 = "10";
         String parserTest3 = "this.causes :: an |-> error";
+        String parserTest4 =
+            "gamepad1.right_joystick_x\n"+
+            "   :: always |->| logging, # note the comma at the end of this line.\n"+
+            "   # and the semicolon terminating the whole statement.\n"+
+            "   :: changed |-> deadband(0.01) |-> FOC ->| twist;\n";
+        String parserTest5 = "gamepad1.right_joystick_x :: |->| logging";
 
-        try {
-            boolean test1 = RecursiveDescentParser.parse(parserTest1);
-            testOutput(parserTest1, test1, true);
-        } catch(ConfigParseException e) {
-            testOutput(parserTest1, e, true);
-        }
-
-        try {
-            boolean test2 = RecursiveDescentParser.parse(parserTest2);
-            testOutput(parserTest2, test2, false);
-        } catch(ConfigParseException e) {
-            testOutput(parserTest2, e, false);
-        }
-
-        try {
-            boolean test3 = RecursiveDescentParser.parse(parserTest3);
-            syntaxErrOutput(parserTest3, test3);
-        } catch(ConfigParseException e) {
-            syntaxErrOutput(parserTest3, e);
-        }
+        parsingTest(parserTest1);
+        parsingTest(parserTest2);
+        parsingTest(parserTest3);
+        parsingTest(parserTest4);
+        parsingTest(parserTest5);
     }
 }

--- a/src/org/usfirst/frc/team5002/io/config/parse/RDParserTest.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/RDParserTest.java
@@ -69,11 +69,24 @@ class RDParserTest {
             "   # and the semicolon terminating the whole statement.\n"+
             "   :: changed |-> deadband(0.01) |-> FOC ->| twist;\n";
 
+        String parserTest6 =
+        "gamepad1\n"+
+        "   .right_joystick_x\n"+
+        "   :: always |->| logging,\n"+
+        "   # filter should still be \"always\" because we set it on the previous line\n"+
+        "   :: |-> deadband(0.01) -> FOC ->| twist,\n"+
+        "   # filter should be \"changed\" here\n"+
+        "   # -- we switched an input, so we go back to the default filter\n"+
+        "   .right_joystick_button\n"+
+        "   :: |->| updateSomething;\n";
+
         parsingTest("gamepad1.left_joystick_y :: always  |-> foc ->| forward;");
         parsingTest("10");
         parsingTest("this.causes :: an |-> error");
         parsingTest("this.however :: is -> not -> an ->| error");
         parsingTest(parserTest4);
         parsingTest("gamepad1.right_joystick_x :: |->| logging");
+        parsingTest(parserTest6);
+        parsingTest("gamepad1.right_joystick_x :: |->| test .right_joystick_button :: |->| test");
     }
 }

--- a/src/org/usfirst/frc/team5002/io/config/parse/RecursiveDescentParser.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/RecursiveDescentParser.java
@@ -1,0 +1,285 @@
+/**
+ * @file RecursiveDescentParser.java
+ * @brief Implements a recursive descent parser for the PML syntax.
+ *
+ * This file implements a
+ * (recursive descent parser)[https://en.wikipedia.org/wiki/Recursive_descent_parser]
+ * for PML syntax, defined by the following EBNF:
+ * ```ebnf
+ * letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
+ *       | "H" | "I" | "J" | "K" | "L" | "M" | "N"
+ *       | "O" | "P" | "Q" | "R" | "S" | "T" | "U"
+ *       | "V" | "W" | "X" | "Y" | "Z" | "a" | "b"
+ *       | "c" | "d" | "e" | "f" | "g" | "h" | "i"
+ *       | "j" | "k" | "l" | "m" | "n" | "o" | "p"
+ *       | "q" | "r" | "s" | "t" | "u" | "v" | "w"
+ *       | "x" | "y" | "z" ;
+ * digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+ * character = letter | digit | "_" | "-";
+ *
+ * identifier = letter, { character };
+ * parameter = character, { character };
+ *
+ * parameter_set = '(', { parameter, ',' }, parameter, ')';
+ * parameterized_identifier = identifier, [parameter_set];
+ *
+ * input_specifier = identifier, '.', identifier, '::', [parameterized_identifier];
+ * pipeline_stage = '|->', parameterized_identifier;
+ * pipeline_callback = '->|', identifier;
+ *
+ * pipeline = input_specifier, { pipeline_stage }, pipeline_callback, ';';
+ * ```
+ *
+ * @author Sebastian Mobo
+ * @date 04-Nov-2017
+ * @version 0.1.0
+ */
+
+package org.usfirst.frc.team5002.io.config.parse;
+
+import java.util.regex.Pattern;
+import org.usfirst.frc.team5002.io.config.exception.ConfigParseException;
+
+
+class RecursiveDescentParser {
+    //! Matches identifiers: any letter, followed by zero or more
+    //! letters / digits / hyphens / underscores.
+    private static final Pattern identifier = Pattern.compile("[a-zA-Z][\\w[\\-]]*");
+
+    //! Matches parameter values: a sequence of one or more
+    //! letters / digits / hyphens / underscores.
+    private static final Pattern parameter = Pattern.compile("[\\w[\\-]]+");
+
+    //! Matches '|->' (token beginning pipeline stages)
+    private static final Pattern stageBegin = Pattern.compile('\\|\\-\\>');
+
+    //! Matches '->|' (token ending pipelines)
+    private static final Pattern pipelineEnd = Pattern.compile('\\-\\>\\|');
+
+    //! Matches '::' (token in pipeline input specifiers)
+    private static final Pattern doubleColon = Pattern.compile('\\:\\:');
+
+    private String input;
+    private Matcher matcher;
+
+    //! Contains the last multicharacter token consumed via the consume(Pattern)
+    //! method.
+    private String lastConsumedToken;
+
+    public RecursiveDescentParser(String input) {
+        this.input = input;
+        this.matcher = identifierPattern.matcher(input);
+    }
+
+    /**
+     * Tests whether or not the next character in the matcher region matches
+     * a single character.
+     *
+     * This method will advance the matcher region if it does find a match.
+     *
+     * @param characterToConsume character to find in the matcher region
+     */
+    private boolean consume(char characterToConsume) {
+        if(input.charAt(matcher.regionStart()) == characterToConsume) {
+            matcher.region(matcher.regionStart()+1, matcher.regionEnd());
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Attempts to find a pattern from the beginning of the matcher region.
+     *
+     * This method will advance the matcher region if it does find a match.
+     */
+    private boolean consume(Pattern tokenToConsume) {
+        if(matcher.pattern() != tokenToConsume) {
+            matcher.usePattern(tokenToConsume);
+        }
+
+        if(matcher.lookingAt()) {
+            lastConsumedToken = matcher.group();
+            matcher.region(matcher.end(), matcher.regionEnd());
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Attempts to match a parameter set.
+     *
+     * The rule defining parameter sets is:
+     * `parameter_set = '(', { parameter, ',' }, parameter, ')';`
+     *
+     * @return true if this token can be found, false otherwise
+     * @throws ConfigParseException if a syntax error is encountered
+     */
+    private boolean parameter_set() {
+        if(consume('(')) {
+            while(consume(parameter)) {
+                //! TODO: maybe we should save parameter values somewhere?
+                if(consume(')')) {
+                    return true;
+                } else if(!consume(',')) {
+                    throw new ConfigParseException("parameter_set: expected ','");
+                }
+            }
+            throw new ConfigParseException(
+                "parameter_set: expected at least one parameter"
+            );
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to match an identifier, possibly with parameters.
+     *
+     * The rule defining parameterized identifiers is:
+     * `parameterized_identifier = identifier, [parameter_set];`
+     *
+     * @return true if this token can be found, false otherwise
+     * @throws ConfigParseException if a syntax error is encountered
+     */
+    private boolean parameterized_identifier() {
+        if(consume(identifier)) {
+            //! TODO: save identifier values (along with any parameters)
+            //! somewhere, perhaps?
+
+            parameter_set(); // optional; disregard return value for now
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to match a pipeline input specifier.
+     *
+     * The rule defining input specifiers is:
+     * `input_specifier =
+     *      identifier, '.', identifier, '::', [parameterized_identifier];`
+     * where the first two identifiers are the device and input names,
+     * respectively, and the parameterized identifier is an optional filter.
+     *
+     * @return true if this token can be found, false otherwise
+     * @throws ConfigParseException if a syntax error is encountered
+     */
+    private boolean input_specifier() {
+        if(consume(identifier)) {
+            //! TODO: should probably store input device somewhere
+            if(!consume('.')) throw new ConfigParseException(
+                "input_specifier: expected '.'"
+            );
+
+            if(!consume(identifier)) throw new ConfigParseException(
+                "input_specifier: expected input name"
+            );
+
+            //! TODO: should store input name somewhere too
+
+            if(!consume(doubleColon)) throw new ConfigParseException(
+                "input_specifier: expected '::'"
+            );
+
+            //! TODO: also store filter values / parameter somewhere
+            parameterized_identifier();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to match a pipeline stage specifier.
+     *
+     * The rule defining pipeline stages is:
+     * `pipeline_stage = '|->', parameterized_identifier;`
+     *
+     * @return true if this token can be found, false otherwise
+     * @throws ConfigParseException if a syntax error is encountered
+     */
+    private boolean pipeline_stage() {
+        if(consume(stageBegin)) {
+            if(!parameterized_identifier()) throw new ConfigParseException(
+                "pipeline_stage: expected identifier"
+            );
+
+            //! TODO: save stage data somewhere?
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to match a pipeline callback specifier.
+     *
+     * The rule defining pipeline stages is:
+     * `pipeline_callback = '->|', identifier;`
+     *
+     * @return true if this token can be found, false otherwise
+     * @throws ConfigParseException if a syntax error is encountered
+     */
+    private boolean pipeline_callback() {
+        if(consume(pipelineEnd)) {
+            if(!consume(identifier)) throw new ConfigParseException(
+                "pipeline_callback: expected identifier"
+            );
+
+            //! TODO: save pipeline callback name somewhere?
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to match a pipeline definition.
+     *
+     * The rule defining pipeline definitions is:
+     * `pipeline = input_specifier, { pipeline_stage }, pipeline_callback;`
+     *
+     * @return true if this token can be found, false otherwise
+     * @throws ConfigParseException if a syntax error is encountered
+     */
+    private boolean pipeline() {
+        if(input_specifier()) {
+            //! TODO: probably should save pipeline input data somewhere
+
+            while(pipeline_stage()) {
+                //! TODO: we should probably save pipeline stages somewhere
+            };
+
+            if(!pipeline_callback()) throw new ConfigParseException(
+                "pipeline: expected pipeline callback specifier"
+            );
+
+            //! TODO: should also save pipeline callback data somewhere
+
+            if(!consume(';')) throw new ConfigParseException(
+                "pipeline: expected semicolon"
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Attempts to parse a pipeline specification.
+     *
+     * @param input a string containing a pipeline specification to parse
+     * @return true if the string contained a valid pipeline specification,
+     * false otherwise
+     * @throws ConfigParseException if a syntax error is encountered
+     */
+    public static boolean parse(String input) {
+        RecursiveDescentParser parser = new RecursiveDescentParser(input);
+        return parser.pipeline();
+    }
+}

--- a/src/org/usfirst/frc/team5002/io/config/parse/RecursiveDescentParser.java
+++ b/src/org/usfirst/frc/team5002/io/config/parse/RecursiveDescentParser.java
@@ -3,7 +3,7 @@
  * @brief Implements a recursive descent parser for the PML syntax.
  *
  * This file implements a
- * (recursive descent parser)[https://en.wikipedia.org/wiki/Recursive_descent_parser]
+ * [recursive descent parser](https://en.wikipedia.org/wiki/Recursive_descent_parser)
  * for PML syntax, defined by the following EBNF:
  * ```ebnf
  * letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"


### PR DESCRIPTION
This is a handwritten [recursive descent parser](https://en.wikipedia.org/wiki/Recursive_descent_parser) for the PML syntax. 

This is _only_ a parser; I don't know how the parser is supposed to instantiate anything, so as of right now the parser does nothing with the data it parses.

Modifying the parser to actually store data would be fairly easy; just use `lastConsumedToken` after successful (true-returning) `consume(Pattern)` calls to get the matched token. 